### PR TITLE
Add a contact link in footer

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -55,11 +55,12 @@
 			</figure>
 		</section>
 
+		<a href="https://doc.openfisca.fr" class="cta">Get started  🙌</a>
 		<footer>
-			<a href="https://doc.openfisca.fr" class="cta">Get started  🙌</a>
 			<ul>
 				<li>Homepage</li>
 				<li><a href="tracking.html">Analytics policy</a></li>
+				<li><a href="mailto:contact@openfisca.org?Subject=openfisca.org">✉️ Contact Us</a></li>
 				<li>
 					<a id="github" target="_blank"><img src="assets/image/GitHub-Mark-Light-64px.png" alt=""/> Contribute to this page</a>
 				</li>

--- a/public/index.html
+++ b/public/index.html
@@ -60,7 +60,7 @@
 			<ul>
 				<li>Homepage</li>
 				<li><a href="tracking.html">Analytics policy</a></li>
-				<li><a href="mailto:contact@openfisca.org?Subject=openfisca.org">✉️ Contact Us</a></li>
+				<li><a href="mailto:contact@openfisca.org?Subject=openfisca.org">Contact Us</a></li>
 				<li>
 					<a id="github" target="_blank"><img src="assets/image/GitHub-Mark-Light-64px.png" alt=""/> Contribute to this page</a>
 				</li>


### PR DESCRIPTION
Fixes #15 

Adds a mailto `contact@openfisca.org` in the footer
Sets the subject to `openfisca.org`
> #17 CSS used for current footer. 