### PR TITLE
Add Legal Notice page

### DIFF
--- a/public/assets/css/index.css
+++ b/public/assets/css/index.css
@@ -1,9 +1,3 @@
-@media (min-width: 960px) {
-	section {
-		flex-direction: row;
-	}
-}
-
 header {
 	padding-top: 1em;
 	padding-bottom: 1em;
@@ -20,4 +14,19 @@ h1 {
 	margin: 5em auto 0 auto;
 	width: 10em;
 	display: block;
+}
+
+
+@media (min-width: 960px) {
+	section {
+		flex-direction: row;
+	}
+
+	figure {
+		width: 45%;
+	}
+
+	.usecase {
+		width: 50%
+	}
 }

--- a/public/assets/css/legal-notice.css
+++ b/public/assets/css/legal-notice.css
@@ -1,0 +1,24 @@
+#legal-notice {
+    display: flex;
+    flex-flow: column;
+}
+
+#legal-notice section {
+    margin-top: 0;
+    padding-top: 0;
+}
+
+#legal-notice h3 {
+    margin-top: 0;
+}
+
+@media (min-width: 960px) {
+
+    #legal-notice {
+    flex-flow: row;
+    }
+
+    #legal-notice section:first-child {
+        border-right: solid 1px;
+    }
+}

--- a/public/assets/css/main.css
+++ b/public/assets/css/main.css
@@ -124,13 +124,3 @@ footer ul li+li {
 footer img {
 	max-width: 1em;
 }
-
-@media (min-width: 960px) {
-	section div {
-		width: 50%;
-	}
-
-	figure {
-		width: 45%;
-	}
-}

--- a/public/assets/css/main.css
+++ b/public/assets/css/main.css
@@ -60,6 +60,12 @@ figcaption {
 	padding-top: 1em;
 }
 
+.content {
+	max-width: 42em;
+	margin: auto;
+	padding: 1em;
+}
+
 .cta {
 	margin: 2em auto;
 	max-width: 10em;

--- a/public/assets/css/main.css
+++ b/public/assets/css/main.css
@@ -100,18 +100,17 @@ footer {
 
 	margin-top: 2em;
 	padding: 1em;
-	background-color: #222;	
+	background-color: #222;
 }
 
 
 footer ul {
-	max-width: 42em;
 	margin: auto;
 	padding: 1em;
 
 	display: flex;
 	justify-content: center;
-	flex-direction: row;
+	flex-flow: row wrap;
 }
 
 footer ul li {

--- a/public/index.html
+++ b/public/index.html
@@ -60,10 +60,11 @@
 			<ul>
 				<li>Homepage</li>
 				<li><a href="tracking.html">Analytics policy</a></li>
-				<li><a href="mailto:contact@openfisca.org?Subject=openfisca.org">Contact Us</a></li>
 				<li>
 					<a id="github" target="_blank"><img src="assets/image/GitHub-Mark-Light-64px.png" alt=""/> Contribute to this page</a>
 				</li>
+				<li><a href="mailto:contact@openfisca.org?Subject=openfisca.org">Contact Us</a></li>
+				<li><a href="./legal-notice.html">Legal notice</a></li>
 			</ul>
 		</footer>
 

--- a/public/index.html
+++ b/public/index.html
@@ -20,7 +20,7 @@
 		</header>
 
 		<section>
-			<div>
+			<div class="usecase">
 				<h3>Calculate citizens' rights</h3>
 				<p>From an individual situation, calculate any variable of a national tax and benefit system.</p>
 			</div>
@@ -32,7 +32,7 @@
 		</section>
 
 		<section>
-			<div>
+			<div class="usecase">
 				<h3>Assess company taxes</h3>
 				<p>Model any kind of entity and evaluate its eligibility to fiscal obligations and benefits.</p>
 			</div>
@@ -44,7 +44,7 @@
 		</section>
 
 		<section>
-			<div>
+			<div class="usecase">
 				<h3>Evaluate reforms impact</h3>
 				<p>Compare the law now to what it could be.</p>
 			</div>

--- a/public/index.html
+++ b/public/index.html
@@ -58,7 +58,7 @@
 		<a href="https://doc.openfisca.fr" class="cta">Get started  🙌</a>
 		<footer>
 			<ul>
-				<li>Homepage</li>
+				<li><a href="index.html">Homepage</a></li>
 				<li><a href="tracking.html">Analytics policy</a></li>
 				<li>
 					<a id="github" target="_blank"><img src="assets/image/GitHub-Mark-Light-64px.png" alt=""/> Contribute to this page</a>

--- a/public/legal-notice.html
+++ b/public/legal-notice.html
@@ -11,12 +11,11 @@
 	</head>
 	<body>
 		<header>
-			<a href="./index.html">
-				<img id="logo" src="assets/image/logo-openfisca.svg" alt="OpenFisca">
+			<a href="index.html">
+			<img id="logo-small" src="assets/image/logo-openfisca.svg" alt="OpenFisca">
 			</a>
 
 			<h1>Turn law into software</h1>
-			<a href="https://doc.openfisca.fr" class="cta">Get started  🙌</a>
 		</header>
 		<div class="content">
 		<h2>About this site</h2>

--- a/public/legal-notice.html
+++ b/public/legal-notice.html
@@ -45,11 +45,21 @@
 		</div>
 </div>
 		<footer>
-			<a href="https://doc.openfisca.fr" class="cta">Get started  🙌</a>
 			<ul>
-				<li><a href="./index.html">Home</a></li>
-				<li><a href="#">Legal notice</a></li>
+				<li><a href="index.html">Homepage</a></li>
+				<li><a href="tracking.html">Analytics policy</a></li>
+				<li>
+					<a id="github" target="_blank"><img src="assets/image/GitHub-Mark-Light-64px.png" alt=""/> Contribute to this page</a>
+				</li>
+				<li><a href="mailto:contact@openfisca.org?Subject=openfisca.org">Contact Us</a></li>
+				<li><a href="./legal-notice.html">Legal notice</a></li>
 			</ul>
 		</footer>
-	</body>
+
+		<script type="text/javascript" src="assets/scripts/edit-page.js"></script>
+		<script type="text/javascript" src="assets/scripts/track-page.js"></script>
+		<noscript>
+			openfisca.org needs JavaScript to work properly.
+			Please follow <a href="http://www.enable-javascript.com">instructions to activate JavaScript in your browser</a>.
+		</noscript>
 </html>

--- a/public/legal-notice.html
+++ b/public/legal-notice.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<meta http-equiv="X-UA-Compatible" content="IE=edge">
+		<link rel="icon" href="assets/image/favicon.ico">
+
+		<title>OpenFisca - Turn law into software</title>
+
+		<link rel="stylesheet" type="text/css" href="assets/css/main.css">
+	</head>
+	<body>
+		<header>
+			<a href="./index.html">
+				<img id="logo" src="assets/image/logo-openfisca.svg" alt="OpenFisca">
+			</a>
+
+			<h1>Turn law into software</h1>
+			<a href="https://doc.openfisca.fr" class="cta">Get started  🙌</a>
+		</header>
+
+		<section>
+			<h2>About this site</h2>
+		</section>
+
+		<section>
+			<h3>Editor</h3>
+			<div>
+				<p>Etalab</p>
+				<ul>
+					<li><a href="https://www.etalab.gouv.fr/en/">https://www.etalab.gouv.fr/en/</a></li>
+					<li>39–43 quai André-Citroën, 75015 Paris</li>
+				</ul>
+				<p>Editorial director</p>
+				<ul><li>Etalab Director - Laure Lucchesi</li></ul>
+			</div>
+		</section>
+
+		<section>
+			<h3>Hosting provider</h3>
+			<div>
+				<p>
+					<a href="https://enterprise.github.com">GitHub, Inc</a>
+				</p>
+				<ul>
+					<li>88 Colin P Kelly Jr St</li>
+					<li>San Francisco, CA 94107 - United States</li>
+					<li><a href="tel:+1-877-448-4820">+1 (877) 448-4820</a></li>
+				</ul>
+			</div>
+		</section>
+
+		<footer>
+			<a href="https://doc.openfisca.fr" class="cta">Get started  🙌</a>
+			<ul>
+				<li><a href="./index.html">Home</a></li>
+				<li><a href="#">Legal notice</a></li>
+			</ul>
+		</footer>
+	</body>
+</html>

--- a/public/legal-notice.html
+++ b/public/legal-notice.html
@@ -8,6 +8,7 @@
 		<title>OpenFisca - Turn law into software</title>
 
 		<link rel="stylesheet" type="text/css" href="assets/css/main.css">
+		<link rel="stylesheet" type="text/css" href="assets/css/legal-notice.css">
 	</head>
 	<body>
 		<header>
@@ -18,31 +19,36 @@
 			<h1>Turn law into software</h1>
 		</header>
 		<div class="content">
-		<h2>About this site</h2>
+			<h2>Legal notice</h2>
+			<div id="legal-notice">
+				<section>
+					<h3>Editor</h3>
+					<div>
+						<p>Etalab</p>
+						<ul>
+							<li><a href="https://www.etalab.gouv.fr/en/">https://www.etalab.gouv.fr/en/</a></li>
+							<li>39–43 quai André-Citroën, 75015 Paris</li>
+						</ul>
+						<p>Editorial director</p>
+						<ul><li>Etalab Director - Laure Lucchesi</li></ul>
+					</div>
+				</section>
 
-		<h3>Editor</h3>
-		<div>
-			<p>Etalab</p>
-			<ul>
-				<li><a href="https://www.etalab.gouv.fr/en/">https://www.etalab.gouv.fr/en/</a></li>
-				<li>39–43 quai André-Citroën, 75015 Paris</li>
-			</ul>
-			<p>Editorial director</p>
-			<ul><li>Etalab Director - Laure Lucchesi</li></ul>
+				<section>
+					<h3>Hosting provider</h3>
+					<div>
+						<p>
+							<a href="https://enterprise.github.com">GitHub, Inc</a>
+						</p>
+						<ul>
+							<li>88 Colin P Kelly Jr St</li>
+							<li>San Francisco, CA 94107 - United States</li>
+							<li><a href="tel:+1-877-448-4820">+1 (877) 448-4820</a></li>
+						</ul>
+					</div>
+				</section>
+			</div>
 		</div>
-
-		<h3>Hosting provider</h3>
-		<div>
-			<p>
-				<a href="https://enterprise.github.com">GitHub, Inc</a>
-			</p>
-			<ul>
-				<li>88 Colin P Kelly Jr St</li>
-				<li>San Francisco, CA 94107 - United States</li>
-				<li><a href="tel:+1-877-448-4820">+1 (877) 448-4820</a></li>
-			</ul>
-		</div>
-</div>
 		<footer>
 			<ul>
 				<li><a href="index.html">Homepage</a></li>

--- a/public/legal-notice.html
+++ b/public/legal-notice.html
@@ -18,38 +18,32 @@
 			<h1>Turn law into software</h1>
 			<a href="https://doc.openfisca.fr" class="cta">Get started  🙌</a>
 		</header>
+		<div class="content">
+		<h2>About this site</h2>
 
-		<section>
-			<h2>About this site</h2>
-		</section>
+		<h3>Editor</h3>
+		<div>
+			<p>Etalab</p>
+			<ul>
+				<li><a href="https://www.etalab.gouv.fr/en/">https://www.etalab.gouv.fr/en/</a></li>
+				<li>39–43 quai André-Citroën, 75015 Paris</li>
+			</ul>
+			<p>Editorial director</p>
+			<ul><li>Etalab Director - Laure Lucchesi</li></ul>
+		</div>
 
-		<section>
-			<h3>Editor</h3>
-			<div>
-				<p>Etalab</p>
-				<ul>
-					<li><a href="https://www.etalab.gouv.fr/en/">https://www.etalab.gouv.fr/en/</a></li>
-					<li>39–43 quai André-Citroën, 75015 Paris</li>
-				</ul>
-				<p>Editorial director</p>
-				<ul><li>Etalab Director - Laure Lucchesi</li></ul>
-			</div>
-		</section>
-
-		<section>
-			<h3>Hosting provider</h3>
-			<div>
-				<p>
-					<a href="https://enterprise.github.com">GitHub, Inc</a>
-				</p>
-				<ul>
-					<li>88 Colin P Kelly Jr St</li>
-					<li>San Francisco, CA 94107 - United States</li>
-					<li><a href="tel:+1-877-448-4820">+1 (877) 448-4820</a></li>
-				</ul>
-			</div>
-		</section>
-
+		<h3>Hosting provider</h3>
+		<div>
+			<p>
+				<a href="https://enterprise.github.com">GitHub, Inc</a>
+			</p>
+			<ul>
+				<li>88 Colin P Kelly Jr St</li>
+				<li>San Francisco, CA 94107 - United States</li>
+				<li><a href="tel:+1-877-448-4820">+1 (877) 448-4820</a></li>
+			</ul>
+		</div>
+</div>
 		<footer>
 			<a href="https://doc.openfisca.fr" class="cta">Get started  🙌</a>
 			<ul>

--- a/public/tracking.html
+++ b/public/tracking.html
@@ -15,8 +15,7 @@
 			<a href="index.html">
 			<img id="logo-small" src="assets/image/logo-openfisca.svg" alt="OpenFisca">
 			</a>
-
-			<h1>Cookies and opt-out</h1>
+			<h1>Turn law into software</h1>
 		</header>
 
 		<section>

--- a/public/tracking.html
+++ b/public/tracking.html
@@ -17,23 +17,25 @@
 			</a>
 			<h1>Turn law into software</h1>
 		</header>
+			<div class="content">
+			<h2>Cookies and opt-out</h2>
+			<section>
+				<p>
+					When you visit this website, we leave a small text file (a "cookie") on your computer. This helps us measure how many visits we've had and which pages are most viewed.
+				</p>
+				<iframe class="optout" src="https://stats.data.gouv.fr/index.php?module=CoreAdminHome&action=optOut&language=en"></iframe>
 
-		<section>
-			<p>
-				When you visit this website, we leave a small text file (a "cookie") on your computer. This helps us measure how many visits we've had and which pages are most viewed.
-			</p>
-			<iframe class="optout" src="https://stats.data.gouv.fr/index.php?module=CoreAdminHome&action=optOut&language=en"></iframe>
-
-			<h2>This website does not show a consent banner for cookies, why?</h2>
-			<p>
-				Our tracking service, <a href="https://www.piwik.org">Piwik</a> is configured in compliance with the <a href="https://www.cnil.fr/fr/solutions-pour-la-mesure-daudience"  hreflang="fr-FR">"Cookies" recommandations (French)</a> from the French authorities (<abbr title="Commission Nationale de l'Informatique et des Libertés">CNIL</abbr>)
-				(i.e. Piwik anonymizes your IP address to make it impossible to link your visit to you personally).
-			</p>
-			<h2>I contribute to your data, can I access it?</h2>
-			<p>
-				Of course! The analytics data for OpenFisca is freely available on <a href="http://stats.data.gouv.fr/index.php?module=CoreHome&action=index&idSite=4&period=range&date=previous30#?module=Dashboard&action=embeddedIndex&idSite=4&period=range&date=previous30&idDashboard=1">stats.data.gouv.fr</a>.
-			</p>
-		</section>
+				<h3>This website does not show a consent banner for cookies, why?</h3>
+				<p>
+					Our tracking service, <a href="https://www.piwik.org">Piwik</a> is configured in compliance with the <a href="https://www.cnil.fr/fr/solutions-pour-la-mesure-daudience"  hreflang="fr-FR">"Cookies" recommandations (French)</a> from the French authorities (<abbr title="Commission Nationale de l'Informatique et des Libertés">CNIL</abbr>)
+					(i.e. Piwik anonymizes your IP address to make it impossible to link your visit to you personally).
+				</p>
+				<h3>I contribute to your data, can I access it?</h3>
+				<p>
+					Of course! The analytics data for OpenFisca is freely available on <a href="http://stats.data.gouv.fr/index.php?module=CoreHome&action=index&idSite=4&period=range&date=previous30#?module=Dashboard&action=embeddedIndex&idSite=4&period=range&date=previous30&idDashboard=1">stats.data.gouv.fr</a>.
+				</p>
+			</section>
+		</div>
 		<footer>
 			<ul>
 				<li><a href="index.html">Homepage</a></li>

--- a/public/tracking.html
+++ b/public/tracking.html
@@ -38,10 +38,12 @@
 		<footer>
 			<ul>
 				<li><a href="index.html">Homepage</a></li>
-				<li>Analytics policy</li>
+				<li><a href="tracking.html">Analytics policy</a></li>
 				<li>
 					<a id="github" target="_blank"><img src="assets/image/GitHub-Mark-Light-64px.png" alt=""/> Contribute to this page</a>
 				</li>
+				<li><a href="mailto:contact@openfisca.org?Subject=openfisca.org">Contact Us</a></li>
+				<li><a href="./legal-notice.html">Legal notice</a></li>
 			</ul>
 		</footer>
 


### PR DESCRIPTION
Fixes #12 

* Adds a new page "Legal Notice" with site editor (Etalab, LL) and Hosting provider (GitHub Inc)
* Adds a link to this new page on homepage's footer