### PR TITLE
Revert adding Catalonia to country packages

### DIFF
--- a/content/countries.en.md
+++ b/content/countries.en.md
@@ -2,7 +2,6 @@
 title: "Available country packages"
 layout: countries
 
-cat: "Catalonia"
 fr: "France"
 tn: "Tunisia"
 sn: "Senegal"

--- a/content/countries.fr.md
+++ b/content/countries.fr.md
@@ -2,7 +2,6 @@
 title: "Country Packages disponibles"
 layout: countries
 
-cat: "Catalogne"
 fr: "France"
 tn: "Tunisie"
 sn: "Sénégal"

--- a/layouts/_default/countries.html
+++ b/layouts/_default/countries.html
@@ -28,16 +28,6 @@
 
     <section class="row">
         <div class="left-col">
-            <h3>{{ $.Param "cat" }}</h3>
-            <div id="gradientcat"></div>
-            <p>
-                {{ $.Param "sources_introduction" }} <a href="https://github.com/jvalduvieco/openfisca-barcelona">github</a>.
-            </p>
-        </div>
-    </section>
-
-    <section class="row">
-        <div class="left-col">
             <h3>{{ $.Param "sn" }}</h3>
             <div id="gradientsn"></div>
             <p>

--- a/static/css/countries.css
+++ b/static/css/countries.css
@@ -1,8 +1,3 @@
-#gradientcat {
-    border: 2px solid;
-    border-image:linear-gradient(to right, rgb(251, 222, 68), rgb(220, 60, 40), rgb(251, 222, 68), rgb(220, 60, 40), rgb(251, 222, 68), rgb(220, 60, 40), rgb(251, 222, 68), #fff) 1;
-}
-
 #gradientfr {
     border: 2px solid;
     border-image:linear-gradient(to right, #fff, blue, white, red, #fff) 1;


### PR DESCRIPTION
Reverts #26

As expressed in #26, I propose to revert changes due to:

- Developer has manifested his wish to wait until May to list the
repository in the available country packages section

- As the section is labelled "country package", and as in this particular case the package is called "openfisca-barcelona", I'd rather try to avoid creating any confusion or misunderstanding by calling it « Catalonia », and to wait the developer to decide the best moment and way to list the package