### PR TITLE
Bypass Jekyll processing on ghpages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,9 @@ jobs:
           command: hugo
       - run:
           name: Publish openfisca.org
-          command: npm run publish
+          command: |
+            touch public/.nojekyll # Bypass Jekyll processing on GitHub Pages
+            npm run publish
       - run:
           name: Publish openfisca.org/doc
           command: ./publish-doc.sh

--- a/publish-doc.sh
+++ b/publish-doc.sh
@@ -12,5 +12,5 @@ cd openfisca.org
 git add .
 git config --global user.name "OpenFisca-Bot"
 git config --global user.email "contact@openfisca.fr"
-git commit --message="Add latest doc version"
+git commit --message="[skip ci] Add latest doc version"
 git push https://github.com/openfisca/openfisca.org.git gh-pages

--- a/publish.js
+++ b/publish.js
@@ -8,6 +8,7 @@ ghpages.publish(
     },
     branch: 'gh-pages',
     message: 'Auto-commit from master branch',
+    dotfiles: true,  // Keep .nojekyll
   },
   function(err) {
     if (err) {

--- a/publish.js
+++ b/publish.js
@@ -7,8 +7,8 @@ ghpages.publish(
       name: 'OpenFisca-Bot',
     },
     branch: 'gh-pages',
-    message: 'Auto-commit from master branch',
-    dotfiles: true,  // Keep .nojekyll
+    message: '[skip ci] Auto-commit from master branch',
+    dotfiles: true, // Keep .nojekyll
   },
   function(err) {
     if (err) {


### PR DESCRIPTION
Connected to openfisca/openfisca-doc#184

Adds a `.nojekyll` empty file to published `openfisca.org` site content (aka [ghpages branch](https://github.com/openfisca/openfisca.org/tree/gh-pages)).
This also applies to documentation content on `openfisca.org/doc`.
