### PR TITLE
Added both flag colours

### DIFF
--- a/static/css/countries.css
+++ b/static/css/countries.css
@@ -15,7 +15,7 @@
 }
 
 #gradient-nsw {
-    border-image: linear-gradient(to right, #fff, blue, white, red, yellow, red, white, blue, #fff) 1;
+    border-image: linear-gradient(to right, #fff, blue, white, red, yellow, black, #fff) 1;
 }
 
 #gradient-nz {


### PR DESCRIPTION
We acknowledge the Gadigal of the Eora Nation as the traditional custodians of the place we now call Sydney, where we work on our Openfisca country package.

This pull request adds the colours of both the [Australian National Flag](https://en.wikipedia.org/wiki/Flag_of_Australia) and the [Australian Aboriginal Flag](https://en.wikipedia.org/wiki/Australian_Aboriginal_Flag) to our country gradient.

<img width="495" alt="Screenshot 2019-04-01 at 23 42 02" src="https://user-images.githubusercontent.com/827798/55328644-928e9e00-54d8-11e9-992d-69e65ed352df.png">
