### PR TITLE
Add reference to "rules as code" in landing

### DIFF
--- a/content/_index.en.md
+++ b/content/_index.en.md
@@ -1,5 +1,5 @@
 ---
-title: "Turn law into software"
+title: "Write rules as code"
 get_started: Get started
 products: Powered by OpenFisca
 


### PR DESCRIPTION
As "rules as code" becomes the standard theoretical framework within whom OpenFisca is referenced, I think it will help less microsimulation-savvy people to find themselves in the website.

Part of https://trello.com/c/M0VU1GTy/18-cross-reference-doc-with-rac