### PR TITLE
Fix status page link

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,7 +1,7 @@
 <footer>
     <ul>
       <li><a href="mailto:contact@openfisca.org?Subject=openfisca.org">{{ $.Site.Params.contact }}</a></li>
-      <li><a href="https://status.openfisca.org">{{ $.Site.Params.status_monitor }}</a></li>
+      <li><a href="https://stats.uptimerobot.com/A6WQWi553">{{ $.Site.Params.status_monitor }}</a></li>
       <li><a id="github" target="_blank"><img src="/img/GitHub-Mark-Light-64px.png" alt=""/> {{ $.Site.Params.contribute }}</a></li>
       <li><a href="{{ "tracking" | relLangURL }}">{{ $.Site.Params.analytics }}</a></li>
       <li><a href="{{ "legal-notice" | relLangURL }}">{{ $.Site.Params.legal_notice }}</a></li>


### PR DESCRIPTION
This PR fixes the status page link that you can find in the footer of [openfisca.org](https://openfisca.org) website.

**Why should we update it?**

To monitor openfisca services we use the free plan of [UptimeRobot](https://uptimerobot.com).
But UptimeRobot support of linked custom domains for Status Pages on the free plan will be discontinued on May 5th, 2021.
So, our current `status.openfisca.org` will point to a 404 HTTP error. 
This PR suggests to fix it by using UptimeRobot's domain status page knowing that the same content is now available under  [stats.uptimerobot.com](https://stats.uptimerobot.com/A6WQWi553).

This is a quick fix and if you have an idea of a better solution, please feel welcome to share it! 🙂 
