### PR TITLE
Update dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,12 +30,12 @@ jobs:
       - checkout
       - run:
           name: Install html-proofer
-          command: gem install html-proofer
+          command: gem install html-proofer --version 5
       - attach_workspace:
           at: .
       - run:
           name: Check HTML common mistakes
-          command: exec htmlproofer ./public --assume-extension .html --check-sri --disable-external --ignore-empty-alt
+          command: exec htmlproofer ./public --assume-extension .html --check-sri true --disable-external true --ignore-empty-alt true
 
   deploy:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,12 +25,12 @@ jobs:
 
   html_validate:
     docker:
-      - image: cimg/ruby:3.1.2-browsers
+      - image: cimg/ruby:2.7.3-browsers
     steps:
       - checkout
       - run:
           name: Install html-proofer
-          command: gem install html-proofer --version 5
+          command: gem install html-proofer --version 4.4.3
       - attach_workspace:
           at: .
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
           at: .
       - run:
           name: Check HTML common mistakes
-          command: exec htmlproofer ./public --assume-extension .html --check-sri true --disable-external true --ignore-empty-alt true
+          command: exec htmlproofer ./public --assume-extension .html --check-sri true --disable-external true --ignore-empty-alt true --allow-missing-href true
 
   deploy:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  hugo: circleci/hugo@0.3.1
+  hugo: circleci/hugo@1.3.0
 
 jobs:
   test:
@@ -48,8 +48,8 @@ workflows:
     jobs:
       - test
       - hugo/build:
-          version: '0.37'
-          html-proofer: true
+          version: '0.106'
+          html-proofer: false
       - deploy:
           requires:
             - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,20 @@ jobs:
           name: Run tests
           command: npm test
 
+  html_validate:
+    docker:
+      - image: cimg/ruby:3.1.2-browsers
+    steps:
+      - checkout
+      - run:
+          name: Install html-proofer
+          command: gem install html-proofer
+      - attach_workspace:
+          at: .
+      - run:
+          name: Check HTML common mistakes
+          command: exec htmlproofer ./public --assume-extension .html --check-sri --disable-external --ignore-empty-alt
+
   deploy:
     docker:
       - image: circleci/node:lts
@@ -50,10 +64,14 @@ workflows:
       - hugo/build:
           version: '0.106'
           html-proofer: false
+      - html_validate:
+          requires:
+            - hugo/build
       - deploy:
           requires:
             - test
             - hugo/build
+            - html_validate
           filters:
             branches:
               only: master

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
 Thank you for wanting to contribute to OpenFisca! :smiley:
 
 Feel free to contact us or send us pull requests over GitHub.
-For more information on how to do so, please see our [contribution guidelines](http://openfisca.org/doc/contribute/index.html).
+For more information on how to do so, please see our [contribution guidelines](https://openfisca.org/doc/contribute/index.html).

--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-baseURL = "http://openfisca.org/"
+baseURL = "https://openfisca.org/"
 title = "OpenFisca"
 theme = "ananke"  # alternatives: https://themes.gohugo.io/github-project-landing-page/ https://themes.gohugo.io/hugo-universal-theme/
 

--- a/layouts/_default/packages.html
+++ b/layouts/_default/packages.html
@@ -53,7 +53,7 @@
                 {{ $.Param "sources_introduction" }} <a href="https://github.com/ServiceInnovationLab/openfisca-aotearoa">GitHub</a>.
             </p> 
         </div>
-        <a href="http://nz.openfisca.org" class="cta">{{ $.Param "explore" }}</a>
+        <a href="https://nz.openfisca.org" class="cta">{{ $.Param "explore" }}</a>
     </section>
 
     <section class="row">
@@ -127,12 +127,12 @@
                 {{ $.Param "sources_introduction" }} <a href="https://github.com/digitalnsw/openfisca-nsw">GitHub</a>.
             </p> 
         </div>
-        <a href="http://nsw-rules.herokuapp.com/" class="cta">{{ $.Param "explore" }}</a>
+        <a href="https://nsw-rules.herokuapp.com/" class="cta">{{ $.Param "explore" }}</a>
     </section>
 
     <section class="row">
         <h3 class="left-col">{{ $.Param "others" }}</h3>
-        <a href="http://openfisca.org/doc/coding-the-legislation/bootstrapping_a_new_country_package.html" class="cta">{{ $.Param "modelize" }}</a>
+        <a href="https://openfisca.org/doc/coding-the-legislation/bootstrapping_a_new_country_package.html" class="cta">{{ $.Param "modelize" }}</a>
     </section>
 </div>
 {{ end }}

--- a/layouts/_default/tracking.html
+++ b/layouts/_default/tracking.html
@@ -18,7 +18,7 @@
 		</p>
 		<h3>{{ $.Param "data.title" }}</h3>
 		<p>
-			{{ $.Param "data.description" }} <a href="http://stats.data.gouv.fr/index.php?module=CoreHome&action=index&idSite=4&period=range&date=previous30#?module=Dashboard&action=embeddedIndex&idSite=4&period=range&date=previous30&idDashboard=1">stats.data.gouv.fr</a>
+			{{ $.Param "data.description" }} <a href="https://stats.data.gouv.fr/index.php?module=CoreHome&action=index&idSite=4&period=range&date=previous30#?module=Dashboard&action=embeddedIndex&idSite=4&period=range&date=previous30&idDashboard=1">stats.data.gouv.fr</a>
 		</p>
 	</section>
 </div>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -68,7 +68,7 @@
 
 			<figure>
 				<img class="screenshot" src="/img/revenu-de-base.jpg" alt="Comment appréhender le coût d’un revenu de base ?">
-				<figcaption><a href="http://www.revenudebase.info/2017/04/07/apprehender-cout-dun-revenu-de-base/">Publication</a> {{ $.Param "usecases.reforms.caption_1" }} <a href="https://openfisca.org/doc/openfisca-python-api/index.html">Python API</a> {{ $.Param "usecases.reforms.caption_2" }}</figcaption>
+				<figcaption><a href="https://www.revenudebase.info/2017/04/07/apprehender-cout-dun-revenu-de-base/">Publication</a> {{ $.Param "usecases.reforms.caption_1" }} <a href="https://openfisca.org/doc/openfisca-python-api/index.html">Python API</a> {{ $.Param "usecases.reforms.caption_2" }}</figcaption>
 			</figure>
 		</section>
 
@@ -80,7 +80,7 @@
 
 			<figure>
 				<img class="screenshot" src="/img/rapu-ture.png" alt="Rapu Ture - Exploring the Rules">
-				<figcaption><a href="http://nz.openfisca.org/">Rapu Ture</a> {{ $.Param "usecases.rapu_ture.caption" }}</figcaption>
+				<figcaption><a href="https://nz.openfisca.org/">Rapu Ture</a> {{ $.Param "usecases.rapu_ture.caption" }}</figcaption>
 			</figure>
 		</section>
 
@@ -89,7 +89,7 @@
 
 			<figure>
 				<img class="screenshot" src="/img/legexp-nsw.png" alt="New South Wales's Legislation Explorer">
-				<figcaption><a href="http://nsw-rules.herokuapp.com/">New South Wales</a> {{ $.Param "usecases.legexp_nsw.caption_1" }} <a href="https://github.com/openfisca/legislation-explorer">Legislation Explorer</a> {{ $.Param "usecases.legexp_nsw.caption_2" }}</figcaption>
+				<figcaption><a href="https://nsw-rules.herokuapp.com/">New South Wales</a> {{ $.Param "usecases.legexp_nsw.caption_1" }} <a href="https://github.com/openfisca/legislation-explorer">Legislation Explorer</a> {{ $.Param "usecases.legexp_nsw.caption_2" }}</figcaption>
 			</figure>
 		</section>
 

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -20,7 +20,7 @@
 
 				<h1>{{ .Title}}</h1>
 
-				<a href="{{ "countries" | relLangURL }}" class="cta get-started">{{ $.Param "get_started" }}  🙌</a>
+				<a href="{{ "packages" | relLangURL }}" class="cta get-started">{{ $.Param "get_started" }}  🙌</a>
 			</div>
 		</header>
 
@@ -93,7 +93,7 @@
 			</figure>
 		</section>
 
-		<a href="{{ "countries" | relLangURL }}" class="cta get-started">{{ $.Param "get_started" }}  🙌</a>
+		<a href="{{ "packages" | relLangURL }}" class="cta get-started">{{ $.Param "get_started" }}  🙌</a>
 
 		{{ partial "footer.html" . }}
 	</body>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -12,5 +12,5 @@
 <script type="text/javascript" src="/scripts/track-page.js"></script>
 <noscript>
     openfisca.org needs JavaScript to work properly.
-    Please follow <a href="http://www.enable-javascript.com">instructions to activate JavaScript in your browser</a>.
+    Please follow <a href="https://www.enable-javascript.com">instructions to activate JavaScript in your browser</a>.
 </noscript>

--- a/package.json
+++ b/package.json
@@ -5,7 +5,10 @@
   "devDependencies": {
     "eslint": "^4.4.1",
     "eslint-config-google": "^0.9.1",
-    "gh-pages": "^1.0.0"
+    "gh-pages": "^4.0.0"
+  },
+  "engines": {
+    "node": ">10"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
That PR update `circleci/hugo` from `0.3.1` to `1.3.0`, `gh-pages` from `^1.0.0` to `^4.0.0` and specify the minimum node version needed.

I haven't found a way other than to disable `html-proofer` for this to work. I will need help to find how to fix the following error shown in CicleCI.  

```console
#!/bin/bash -eo pipefail
htmlproofer ./public \
   \
   --allow-hash-href  \
   \
  --alt-ignore  \
   \
  --checks-to-ignore '' \
   \
   \
   --check-html  \
   \
   \
   \
  --directory-index-file index.html \
   --disable-external  \
   --empty-alt-ignore  \
  --error-sort ''  \
   \
  --extension '.html' \
   \
  --file-ignore '' \
  --http-status-ignore '' \
  --internal-domains '' \
   \
   \
   \
   \
   \
   \
  --log-level info \
   \
  --storage-dir 'tmp/.htmlproofer' \
  --timeframe '1h' \
  --typhoeus-config '{}' \
  --url-ignore '' \
  --url-swap ''

htmlproofer 4.4.3 | Error:  Whoops, we can't understand your command.
htmlproofer 4.4.3 | Error:  invalid option: --checks-to-ignore
Did you mean?  check-internal-hash
htmlproofer 4.4.3 | Error:  Run your command again with the --help switch to see available options.
/var/lib/gems/3.0.0/gems/mercenary-0.4.0/lib/mercenary/program.rb:33:in `go': invalid option: --checks-to-ignore (OptionParser::InvalidOption)
Did you mean?  check-internal-hash
	from /var/lib/gems/3.0.0/gems/mercenary-0.4.0/lib/mercenary.rb:21:in `program'
	from /var/lib/gems/3.0.0/gems/html-proofer-4.4.3/bin/htmlproofer:11:in `<top (required)>'
	from /usr/local/bin/htmlproofer:25:in `load'
	from /usr/local/bin/htmlproofer:25:in `<main>'

Exited with code exit status 1
CircleCI received exit code 1
```