### PR TITLE
Add custom config for staging env

### DIFF
--- a/config/staging/config.yml
+++ b/config/staging/config.yml
@@ -1,0 +1,1 @@
+baseURL: /


### PR DESCRIPTION
Adding a custom configuration for staging environnement which defines `baseURL: /` (instead of `baseURL: https://openfisca.org/`) and configuring the Netlify preview building with the staging env (view the following screenshot) allow to fix #105 

![image](https://user-images.githubusercontent.com/364319/213205873-628621a9-10f5-41cc-b1a6-1613ccfd039c.png)
