### PR TITLE
Fix white space bug in Safari

### DIFF
--- a/themes/OpenFisca-2022/assets/css/components/cards/card.css
+++ b/themes/OpenFisca-2022/assets/css/components/cards/card.css
@@ -23,7 +23,7 @@
 }
 
 .card_flag {
-  margin-top: var(--xs);
+  margin-top: var(--xs2);
   margin-left: var(--xs2);
 }
 

--- a/themes/OpenFisca-2022/assets/css/elements/flags.css
+++ b/themes/OpenFisca-2022/assets/css/elements/flags.css
@@ -1,5 +1,7 @@
 .flag {
-  font-size: 0;
+  & > span {
+    display: none;
+  }
 
   &::after {
     font-size: 2rem;

--- a/themes/OpenFisca-2022/layouts/_default/packages.html
+++ b/themes/OpenFisca-2022/layouts/_default/packages.html
@@ -20,7 +20,7 @@
                         <tr>
                             <td data-column="{{ .Params.columns.jurisdiction }}">
                                 {{ with .jurisdiction }}
-                                    <div class="flag flag-{{ slicestr . 0 2 }}">{{ . }}</div>
+                                    <div class="flag flag-{{ slicestr . 0 2 }}"><span>{{ . }}</span></div>
                                 {{ else }}
                                     <span style="color:var(--colorGray500)">-</span>
                                 {{ end }}

--- a/themes/OpenFisca-2022/layouts/_default/styleguide.html
+++ b/themes/OpenFisca-2022/layouts/_default/styleguide.html
@@ -184,10 +184,10 @@
                         <li class="tag">{{ . }}</li>
                     {{ end }}
                 </ul>
-                <div class="flag flag-FR">FR</div>
-                <div class="flag flag-AD">AD</div>
-                <div class="flag flag-AI">AI</div>
-                <div class="flag flag-IQ">IQ</div>
+                <div class="flag flag-FR"><span>FR</span></div>
+                <div class="flag flag-AD"><span>AD</span></div>
+                <div class="flag flag-AI"><span>AI</span></div>
+                <div class="flag flag-IQ"><span>IQ</span></div>
             </div>
         </div>
     </div>
@@ -317,7 +317,7 @@
                 <tbody>
                     {{ range $.Site.Data.packages }}
                         <tr>
-                            <td data-column="Jurisdiction">{{ if eq .jurisdiction "ZZ" }}<span style="color:var(--colorGray500)">…</span>{{ else }}<div class="flag flag-{{ .jurisdiction }}">{{ .jurisdiction }}</div>{{ end }}</td>
+                            <td data-column="Jurisdiction">{{ if eq .jurisdiction "ZZ" }}<span style="color:var(--colorGray500)">…</span>{{ else }}<div class="flag flag-{{ .jurisdiction }}"><span>{{ .jurisdiction }}</span></div>{{ end }}</td>
                             <td data-column="Title">{{ index .title $.Site.Language.Lang }}</td>
                             <td data-column="Website" class="td-isTruncated">{{ with .website }}<a href="{{ . }}" target="_blank">{{ . }}</a>{{ else }}<span style="color:var(--colorGray500)">…</span>{{ end }}</td>
                             <td data-column="Source" class="td-isTruncated">{{ with .source }}<a href="{{ . }}" target="_blank">{{ . }}</a>{{ else }}<span style="color:var(--colorGray500)">…</span>{{ end }}</td>

--- a/themes/OpenFisca-2022/layouts/partials/card.html
+++ b/themes/OpenFisca-2022/layouts/partials/card.html
@@ -11,7 +11,7 @@
 	</div>
 	<div class="card_titleWrapper">
 		<h3 class="card_title">{{ .title }}</h3>
-		<div class="card_flag flag flag-{{ .country }}">{{ .country }}</div>
+		<div class="card_flag flag flag-{{ .country }}"><span>{{ .country }}</span></div>
 	</div>
 	<div class="card_desc">
 		{{ .description }}


### PR DESCRIPTION
Using a none displaying `<span>` instead of `font-size:0` fix the extra space before the flag reported in #107.

I didn't understand exactly why (and I don't think it's important to invest more time) but it might be the way Safari takes letter spacing into account when rendering an element in font size 0.