### PR TITLE
Validate that URLs are reachable over HTTPS

### DIFF
--- a/test/showcase/schema.js
+++ b/test/showcase/schema.js
@@ -95,7 +95,8 @@ const SPDXLicenseIds = JSON.parse(fs.readFileSync('./node_modules/spdx-license-i
 
 function isUrl(value) {
   try {
-    return new URL(value);
+    const url = new URL(value);
+    return url.protocol == 'https:';
   } catch (_) {
     return false;
   }


### PR DESCRIPTION
This changeset ensures that URLs provided in showcase entries are actually reachable over a web browser. Without it, a protocol such as `htps` is valid.

I made the assumption that every reuse should provide an SSL version. If this cannot be held, we can easily accept HTTP (without HTTPS) as a protocol in the future.