### PR TITLE
Reference package rather than country in showcase entries

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ title: Legislation Explorer  # 80 characters max
 description:  # in both languages, 200 characters max
   en: Explore legislation formulas and parameters modelled with OpenFisca.
   fr: Explorez les formules et les paramètres de la législation modélisée.  # deepl.com can be used for automated translation
-country: ZZ  # ISO 3166-2 format, see https://en.wikipedia.org/wiki/ISO_3166-2
+package: france  # the name of the OpenFisca country package used by this reuse
 website: https://legislation.demo.openfisca.org  # prefer HTTPS over HTTP
 author:
   type: collective # one of individual, collective, ngo, research_center, business, local_government, or national_government

--- a/data/showcase/les_meves_ajudes.yml
+++ b/data/showcase/les_meves_ajudes.yml
@@ -2,7 +2,7 @@ title: Les meves ajudes
 description:
   fr: Les meves ajudes utilise OpenFisca et sa Web API pour informer les citoyens de Barcelone de leur éligibilité aux aides sociales.
   en: Les meves ajudes uses OpenFisca and its Web API to inform Barcelona citizens on their eligibility to social benefits.
-country: ES
+package: barcelona
 website: https://ajuntament.barcelona.cat/lesmevesajudes/
 author:
   type: local_government

--- a/data/showcase/leximpact.yml
+++ b/data/showcase/leximpact.yml
@@ -2,7 +2,7 @@ title: LexImpact
 description:
   fr: LexImpact utilise OpenFisca et son API Python pour simuler l'impact des politiques publiques sur les ménages, grâce à un simulateur dédié à l'impôt sur le revenu.
   en: LexImpact uses OpenFisca and its Python API to evaluate the impact of public policy on households, thanks to an income revenue tax simulator.
-country: FR
+package: france
 website: https://leximpact.beta.gouv.fr/
 author:
   type: national_government

--- a/data/showcase/mes_aides.yml
+++ b/data/showcase/mes_aides.yml
@@ -2,7 +2,7 @@ title: Mes aides
 description:
   fr: Mes Aides utilise OpenFisca et son API Web pour informer les citoyens français de leur éligibilité aux aides nationales et locales.
   en: Mes Aides uses OpenFisca and its Web API to inform French citizens of their eligibility to national and local benefits.
-country: FR #ISO 3166-2 format
+package: france
 website: https://mes-aides.gouv.fr/
 author:
   type: national_government

--- a/data/showcase/policyengine_uk.yml
+++ b/data/showcase/policyengine_uk.yml
@@ -2,7 +2,7 @@ title: PolicyEngine UK
 description:
   fr: PolicyEngine UK utilise un moteur dérivé d'OpenFisca pour permettre d'estimer impôts et aides sociales, ainsi que l'impact de réformes personnalisées.
   en: The PolicyEngine UK web app uses an engine derived from OpenFisca to let anyone estimate their taxes and benefits, and estimate the impact of custom policy reforms.
-country: GB
+package: united-kingdom
 website: https://policyengine.org/uk
 author:
   type: ngo

--- a/data/showcase/policyengine_us.yml
+++ b/data/showcase/policyengine_us.yml
@@ -2,7 +2,7 @@ title: PolicyEngine US
 description:
   fr: PolicyEngine US utilise un moteur dérivé d'OpenFisca pour permettre d'estimer impôts et aides sociales, ainsi que l'impact de réformes personnalisées.
   en: The PolicyEngine US web app uses an engine derived from OpenFisca to let anyone estimate their taxes and benefits, and estimate the impact of custom policy reforms.
-country: US
+package: united-states
 website: https://policyengine.org/us
 author:
   type: ngo

--- a/data/showcase/rapu_ture.yml
+++ b/data/showcase/rapu_ture.yml
@@ -2,7 +2,7 @@ title: Rapu Ture
 description:
   fr: Rapu Ture (Exploring the Rules) utilise OpenFisca pour permettre aux citoyens, aux agents publics, aux experts métier, et aux développeurs d'explorer les règles de la législation néo-zélandaise.
   en: Rapu Ture (Exploring the Rules) is a web interface to explore the rules in New Zealand's Openfisca built from government legislation, regulation and some policies.
-country: NZ
+package: aotearoa-new-zealand
 website: https://nz.openfisca.org/
 author:
   type: national_government

--- a/data/showcase/revenu_de_base.yml
+++ b/data/showcase/revenu_de_base.yml
@@ -2,7 +2,7 @@ title: Revenu de base
 description:
   fr: Publication du Mouvement Français pour un Revenu de Base qui utilise OpenFisca et sa Python API pour évaluer le coût et les bénéfices d'une réforme qui instaurerait un revenu de base en France.
   en: Publication of the French Movement for a Basic Income that uses OpenFisca and its Python API to evaluate the cost and benefits of a reform introducing a basic income in France.
-country: FR
+package: france
 website: https://www.revenudebase.info/2017/04/07/apprehender-cout-dun-revenu-de-base/
 author:
   type: ngo

--- a/test/showcase/schema.js
+++ b/test/showcase/schema.js
@@ -66,6 +66,7 @@ export default {
       min: 2,
       max: 200,
     },
+    use: {isValidPackage},
   },
   until: {
     type: Date,
@@ -119,4 +120,10 @@ function isValidAuthorType(value) {
 
 function isSPDX(value) {
   return SPDXLicenseIds.includes(value);
+}
+
+const packagesFilenames = fs.readdirSync('./data/packages').map((file) => file.replace('.yml', ''));
+
+function isValidPackage(value) {
+  return packagesFilenames.includes(value);
 }

--- a/test/showcase/schema.js
+++ b/test/showcase/schema.js
@@ -59,12 +59,12 @@ export default {
       },
     },
   },
-  country: {
+  package: {
     type: String,
     required: true,
     length: {
       min: 2,
-      max: 2,
+      max: 200,
     },
   },
   until: {

--- a/test/showcase/schema.js
+++ b/test/showcase/schema.js
@@ -62,10 +62,6 @@ export default {
   package: {
     type: String,
     required: true,
-    length: {
-      min: 2,
-      max: 200,
-    },
     use: {isValidPackage},
   },
   until: {

--- a/themes/OpenFisca-2022/layouts/_default/packages.html
+++ b/themes/OpenFisca-2022/layouts/_default/packages.html
@@ -20,7 +20,7 @@
                         <tr>
                             <td data-column="{{ .Params.columns.jurisdiction }}">
                                 {{ with .jurisdiction }}
-                                    <div class="flag flag-{{ slicestr . 0 2 }}"><span>{{ . }}</span></div>
+                                    {{ partial "flag.html" (dict "jurisdiction" . ) }}
                                 {{ else }}
                                     <span style="color:var(--colorGray500)">-</span>
                                 {{ end }}

--- a/themes/OpenFisca-2022/layouts/_default/showcase.html
+++ b/themes/OpenFisca-2022/layouts/_default/showcase.html
@@ -17,7 +17,7 @@
                 {{ $showcase := sort (.Scratch.Get "entries") "title" }}
                 {{ range $showcase }}
                     {{ $description := index .description $.Site.Language.Lang }}
-                    {{ partial "card.html" (dict "id" .id "title" .title "description" $description "country" .country "website" .website "author" .author "Site" $.Site) }}
+                    {{ partial "card.html" (dict "id" .id "title" .title "description" $description "package" .package "website" .website "author" .author "Site" $.Site) }}
                 {{ end }}
             </div>
         </div>
@@ -30,7 +30,7 @@
                 {{ $obsoleteShowcase := sort (.Scratch.Get "obsoleteEntries") "until" "desc" }}
                 {{ range $obsoleteShowcase }}
                     {{ $description := index .description $.Site.Language.Lang }}
-                    {{ partial "card.html" (dict "id" .id "title" .title "description" $description "country" .country "website" .website "author" .author "until" .until "Site" $.Site) }}
+                    {{ partial "card.html" (dict "id" .id "title" .title "description" $description "package" .package "website" .website "author" .author "until" .until "Site" $.Site) }}
                 {{ end }}
             </div>
         </div>

--- a/themes/OpenFisca-2022/layouts/_default/styleguide.html
+++ b/themes/OpenFisca-2022/layouts/_default/styleguide.html
@@ -55,9 +55,9 @@
                  {{ $showcase := sort (.Scratch.Get "showcaseEntries") "title" }}
                  {{ range $showcase }}
                     {{ $description := index .description $.Site.Language.Lang }}
-                    {{ partial "card.html" (dict "id" .id "title" .title "description" $description "country" .country "website" .website "author" .author "Site" $.Site) }}
+                    {{ partial "card.html" (dict "id" .id "title" .title "description" $description "package" .package "website" .website "author" .author "Site" $.Site) }}
                 {{ end }}
-                {{ partial "card.html" (dict "title" "Laboris nisi ut aliquip" "description" "Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum." "country" "FR" "website" "https://www.openfisca.org" "tags" $tags "Site" $.Site) }}
+                {{ partial "card.html" (dict "title" "Laboris nisi ut aliquip" "description" "Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum." "package" "france" "website" "https://www.openfisca.org" "tags" $tags "Site" $.Site) }}
             </div>
             <div class="grid_col-12 text-center mt-l">
                 <a href="#"></a><button>Browse all</button></a>

--- a/themes/OpenFisca-2022/layouts/_default/styleguide.html
+++ b/themes/OpenFisca-2022/layouts/_default/styleguide.html
@@ -193,10 +193,10 @@
                         <li class="tag">{{ . }}</li>
                     {{ end }}
                 </ul>
-                <div class="flag flag-FR"><span>FR</span></div>
-                <div class="flag flag-AD"><span>AD</span></div>
-                <div class="flag flag-AI"><span>AI</span></div>
-                <div class="flag flag-IQ"><span>IQ</span></div>
+                {{ partial "flag.html" (dict "jurisdiction" "FR") }}
+                {{ partial "flag.html" (dict "jurisdiction" "AD") }}
+                {{ partial "flag.html" (dict "jurisdiction" "AI") }}
+                {{ partial "flag.html" (dict "jurisdiction" "IQ") }}
             </div>
         </div>
     </div>
@@ -332,7 +332,7 @@
                 <tbody>
                     {{ range $.Site.Data.packages }}
                         <tr>
-                            <td data-column="Jurisdiction">{{ if eq .jurisdiction "ZZ" }}<span style="color:var(--colorGray500)">…</span>{{ else }}<div class="flag flag-{{ .jurisdiction }}"><span>{{ .jurisdiction }}</span></div>{{ end }}</td>
+                            <td data-column="Jurisdiction">{{ if eq .jurisdiction "ZZ" }}<span style="color:var(--colorGray500)">…</span>{{ else }}{{ partial "flag.html" (dict "jurisdiction" .jurisdiction) }}{{ end }}</td>
                             <td data-column="Title">{{ index .title $.Site.Language.Lang }}</td>
                             <td data-column="Website" class="td-isTruncated">{{ with .website }}<a href="{{ . }}" target="_blank">{{ . }}</a>{{ else }}<span style="color:var(--colorGray500)">…</span>{{ end }}</td>
                             <td data-column="Source" class="td-isTruncated">{{ with .source }}<a href="{{ . }}" target="_blank">{{ . }}</a>{{ else }}<span style="color:var(--colorGray500)">…</span>{{ end }}</td>

--- a/themes/OpenFisca-2022/layouts/index.html
+++ b/themes/OpenFisca-2022/layouts/index.html
@@ -11,7 +11,7 @@
                {{ range $slug := .Param "homepage_featured" }}
                   {{ $showcase := index $.Site.Data.showcase $slug }}
                   {{ $description := index $showcase.description $.Site.Language.Lang }}
-                  {{ partial "card.html" (dict "id" $slug "title" $showcase.title "description" $description "country" $showcase.country "website" $showcase.website "author" $showcase.author "Site" $.Site) }}
+                  {{ partial "card.html" (dict "id" $slug "title" $showcase.title "description" $description "package" $showcase.package "website" $showcase.website "author" $showcase.author "Site" $.Site) }}
                {{ end }}
             </div>
             <div class="grid_col-12 text-center mt-xl2">

--- a/themes/OpenFisca-2022/layouts/partials/card.html
+++ b/themes/OpenFisca-2022/layouts/partials/card.html
@@ -8,13 +8,17 @@
 {{ with .author }}{{ with .type }}{{ $authorType = . }}{{ end }}{{ end }}
 {{ $authorTypeIcon := index .Site.Params.showcase.author.types.icons $authorType }}
 
+{{ $package := index $.Site.Data.packages .package }}
+
 <div class="card {{ if .website }}{{ if not .until }}card-hasLink{{ end }}{{ end }}">
 	<div class="card_image">
 		<img class="screenshot" src="{{ $imageSrc }}" alt="{{ .title }}" />
 	</div>
 	<div class="card_titleWrapper">
 		<h3 class="card_title">{{ .title }}</h3>
-		<div class="card_flag flag flag-{{ .country }}"><span>{{ .country }}</span></div>
+		{{ with $package }}{{ with $package.jurisdiction }}
+			<div class="card_flag flag flag-{{ . }}"><span>{{ . }}</span></div>
+		{{ end }}{{ end }}
 	</div>
 	<div class="card_desc">
 		{{ .description }}

--- a/themes/OpenFisca-2022/layouts/partials/card.html
+++ b/themes/OpenFisca-2022/layouts/partials/card.html
@@ -17,7 +17,7 @@
 	<div class="card_titleWrapper">
 		<h3 class="card_title">{{ .title }}</h3>
 		{{ with $package }}{{ with $package.jurisdiction }}
-			<div class="card_flag flag flag-{{ . }}"><span>{{ . }}</span></div>
+			{{ partial "flag.html" (dict "jurisdiction" . "class" "card_flag") }}
 		{{ end }}{{ end }}
 	</div>
 	<div class="card_desc">

--- a/themes/OpenFisca-2022/layouts/partials/flag.html
+++ b/themes/OpenFisca-2022/layouts/partials/flag.html
@@ -1,0 +1,1 @@
+<div class="flag flag-{{ slicestr .jurisdiction 0 2 }} {{ with .class }}{{ . }}{{ end }}" title="{{ .jurisdiction }}"><span>{{ .jurisdiction }}</span></div>


### PR DESCRIPTION
That changeset replace the `country` reuse metadata by `package` file name.

It still display a flag in the UI by using the  linked package `jurisdiction` code and add test to verify if the `package` is an existing file.