### PR TITLE
Fix leximpact_socio-fiscal showcase repository

### DIFF
--- a/data/showcase/leximpact_impot_revenu.yml
+++ b/data/showcase/leximpact_impot_revenu.yml
@@ -11,4 +11,7 @@ author:
   contact: leximpact@assemblee-nationale.fr
 source:
   repository: https://git.leximpact.dev/leximpact/leximpact-server
+  # web interface: https://git.leximpact.dev/leximpact/leximpact-client
+  # adapt france survey for state budget: https://github.com/openfisca/openfisca-france-data
+  # common data tools for surveys: https://github.com/openfisca/openfisca-survey-manager
   license: AGPL-3.0-only

--- a/data/showcase/leximpact_socio_fiscal.yml
+++ b/data/showcase/leximpact_socio_fiscal.yml
@@ -1,6 +1,8 @@
 title: Simulateur de réformes socio-fiscales — LexImpact
 website: https://socio-fiscal.leximpact.an.fr/
 package: france
+# france_indirect_taxation: https://github.com/openfisca/openfisca-france-indirect-taxation
+# france_reforms: https://git.leximpact.dev/leximpact/openfisca-france-reforms/-/tree/master/openfisca_france_reforms
 description:
   fr: Permettre aux parlementaires d'estimer l'impact d'une modification des cotisations, impôts et prestations sociales sur des cas types ou sur le budget de l'État.
   en: Enable members of Parliament to estimate the impact of a change in non-wage labour costs, taxes and benefits on use cases or on the State budget.
@@ -17,6 +19,6 @@ source:
   # customize models components for interface: https://git.leximpact.dev/leximpact/leximpact-socio-fiscal-openfisca-json
   # detect models components: https://git.leximpact.dev/leximpact/openfisca-json-model
   # adapt openfisca_france_data database for state budget with openfisca scenario: https://git.leximpact.dev/leximpact/leximpact-prepare-data
-  # adapt france survey for state budget: https://github.com/openfisca/openfisca-france-data
+  # link and clean up france survey for state budget: https://github.com/openfisca/openfisca-france-data
   # common data tools for surveys: https://github.com/openfisca/openfisca-survey-manager
   license: AGPL-3.0-only

--- a/data/showcase/leximpact_socio_fiscal.yml
+++ b/data/showcase/leximpact_socio_fiscal.yml
@@ -10,5 +10,13 @@ author:
   contact: leximpact@assemblee-nationale.fr
   link: https://leximpact.an.fr/
 source:
-  repository: https://git.leximpact.dev/leximpact/leximpact-socio-fiscal-ui
+  repository: https://git.leximpact.dev/leximpact/leximpact-socio-fiscal-api
+  # web api for use case calculation: https://git.leximpact.dev/leximpact/leximpact-socio-fiscal-api
+  # web api for state budget calculation: https://git.leximpact.dev/leximpact/leximpact-socio-fiscal-simu-etat
+  # web interface: https://git.leximpact.dev/leximpact/leximpact-socio-fiscal-ui
+  # customize models components for interface: https://git.leximpact.dev/leximpact/leximpact-socio-fiscal-openfisca-json
+  # detect models components: https://git.leximpact.dev/leximpact/openfisca-json-model
+  # adapt openfisca_france_data database for state budget with openfisca scenario: https://git.leximpact.dev/leximpact/leximpact-prepare-data
+  # adapt france survey for state budget: https://github.com/openfisca/openfisca-france-data
+  # common data tools for surveys: https://github.com/openfisca/openfisca-survey-manager
   license: AGPL-3.0-only


### PR DESCRIPTION
* Update `leximpact_socio_fiscal` showcase repository from user interface repository to web api (for use cases calculation) repository which is closer to openfisca.
* In comments, for `leximpact_socio_fiscal` and `leximpact_impot_revenu`, list other packages and repositories.