### PR TITLE
Add missing DPG Alliance reference to main page in French

### DIFF
--- a/content/_index.fr.md
+++ b/content/_index.fr.md
@@ -16,6 +16,10 @@ hero:
       author: Programme Joinup de la Commission européenne
       title: Désigné « Logiciel open-source le plus innovant » en 2019
       link: https://joinup.ec.europa.eu/collection/sharing-and-reuse-it-solutions/sharing-reuse-awards-2019-results#oss-inno
+    - image: dpg.png
+      author: Digital Public Goods Alliance
+      title: Reconnu comme Bien Public Numérique par le PNUD, l'UNICEF et la Norad
+      link: https://app.digitalpublicgoods.net/a/10318
 for_who:
   - title: Administrations et cabinets
     description: OpenFisca permet aux institutions de partager efficacement les mises à jour de la réglementation et de mutualiser les coûts. L'interconnexion des règles entre les organismes publics sous la forme de paramètres lisibles et de code exécutable offre une transparence algorithmique minimale immédiate et réduit les frais pour le contribuable.


### PR DESCRIPTION
This PR fixes the difference between our English and French main page.

Today, the Digital Public Goods Alliance reference exists in the openfisca.org/en/ page:

<img width="70%" alt="Capture d’écran 2024-02-05 à 16 56 18" src="https://github.com/openfisca/openfisca.org/assets/6567910/9756478d-da92-4975-be6d-79aa3ac781c4">

But is is missing from the openfisca.org/fr/ page:

<img width="70%" alt="Capture d’écran 2024-02-05 à 16 56 03" src="https://github.com/openfisca/openfisca.org/assets/6567910/186bc61c-0aa2-405c-b9ab-4941f316cd0e"> 

> Norad refers here to the [[Norwegian Agency for Development Cooperation](https://www.norad.no/en/front/)](https://www.norad.no/en/front/)