### PR TITLE
Add print stylesheet

### DIFF
--- a/themes/OpenFisca-2022/assets/css/loader.css
+++ b/themes/OpenFisca-2022/assets/css/loader.css
@@ -43,6 +43,3 @@
 @import "components/announcement/announcement.css";
 @import "components/sponsors/sponsors.css";
 @import "components/sponsors/sponsor.css";
-
-/* Print */
-@import "print.css" print;

--- a/themes/OpenFisca-2022/assets/css/loader.css
+++ b/themes/OpenFisca-2022/assets/css/loader.css
@@ -43,3 +43,6 @@
 @import "components/announcement/announcement.css";
 @import "components/sponsors/sponsors.css";
 @import "components/sponsors/sponsor.css";
+
+/* Print */
+@import "print.css" print;

--- a/themes/OpenFisca-2022/assets/css/print.css
+++ b/themes/OpenFisca-2022/assets/css/print.css
@@ -6,3 +6,17 @@ footer {
 a {
   color: inherit !important;
 }
+
+.hero-isDark .hero_content,
+.hero-isDark .hero_content * {
+  background-color: transparent !important;
+  color: black !important;
+}
+
+.banner {
+  display: none !important;
+}
+
+.card {
+  border-color: black !important;
+}

--- a/themes/OpenFisca-2022/assets/css/print.css
+++ b/themes/OpenFisca-2022/assets/css/print.css
@@ -1,0 +1,8 @@
+header,
+footer {
+  display: none !important;
+}
+
+a {
+  color: inherit !important;
+}

--- a/themes/OpenFisca-2022/layouts/partials/head.html
+++ b/themes/OpenFisca-2022/layouts/partials/head.html
@@ -6,6 +6,9 @@
 	{{ $styles := resources.Get "css/loader.css" | toCSS | postCSS (dict "config" "./assets/css/postcss.config.cjs" "inlineImports" true) }}
 	{{ if hugo.IsProduction }}{{ $styles = $styles | minify | fingerprint | resources.PostProcess }}{{ end }}
 	<link rel="stylesheet" href="{{ $styles.RelPermalink }}" integrity="{{ $styles.Data.Integrity }}">
+	{{ $printStyles := resources.Get "css/print.css" | toCSS | postCSS (dict "config" "./assets/css/postcss.config.cjs" "inlineImports" true) }}
+	{{ if hugo.IsProduction }}{{ $printStyles = $printStyles | minify | fingerprint | resources.PostProcess }}{{ end }}
+	<link rel="stylesheet" href="{{ $printStyles.RelPermalink }}" media="print" integrity="{{ $printStyles.Data.Integrity }}">
 	<link rel="apple-touch-icon" sizes="180x180" href={{ "favicon/apple-touch-icon.png" | absURL }}>
 	<link rel="icon" type="image/png" sizes="32x32" href={{ "favicon/favicon-32x32.png" | absURL }}>
 	<link rel="icon" type="image/png" sizes="16x16" href={{ "favicon/favicon-16x16.png" | absURL }}>

--- a/themes/OpenFisca-2022/layouts/partials/head.html
+++ b/themes/OpenFisca-2022/layouts/partials/head.html
@@ -4,8 +4,8 @@
 	<meta name="description" content="{{ with .Param "html_description"}}{{ . }}{{ else }}{{ .Summary | truncate 160 }}{{ end }}">
 	<meta name="viewport" content="width=device-width,initial-scale=1" />
 	{{ $styles := resources.Get "css/loader.css" | toCSS | postCSS (dict "config" "./assets/css/postcss.config.cjs" "inlineImports" true) }}
-  {{ if hugo.IsProduction }}{{ $styles = $styles | minify | fingerprint | resources.PostProcess }}{{ end }}
-  <link rel="stylesheet" href="{{ $styles.RelPermalink }}" integrity="{{ $styles.Data.Integrity }}">
+	{{ if hugo.IsProduction }}{{ $styles = $styles | minify | fingerprint | resources.PostProcess }}{{ end }}
+	<link rel="stylesheet" href="{{ $styles.RelPermalink }}" integrity="{{ $styles.Data.Integrity }}">
 	<link rel="apple-touch-icon" sizes="180x180" href={{ "favicon/apple-touch-icon.png" | absURL }}>
 	<link rel="icon" type="image/png" sizes="32x32" href={{ "favicon/favicon-32x32.png" | absURL }}>
 	<link rel="icon" type="image/png" sizes="16x16" href={{ "favicon/favicon-16x16.png" | absURL }}>


### PR DESCRIPTION
A cleaner approach could be to use only `loader.css` with media queries, but that entails adding a new PostCSS plugin to handle the inlining and removing the Hugo pipeline that currently does it. At this stage, I preferred to duplicate the Hugo pipeline with the media query in HTML.